### PR TITLE
0.1.1

### DIFF
--- a/copydetect/data/report.html
+++ b/copydetect/data/report.html
@@ -15,11 +15,11 @@
       <div class="col">
         <h4 style="text-align: center;">Similarity Matrix</h4>
         <img src="figures/sim_matrix.png" alt="Code similarity matrix">
-      </div class="col">
+      </div>
       <div class="col">
         <h4 style="text-align: center;">Similarity Score Distribution</h4>
         <img src="figures/sim_histogram.png" alt="Code similarity histogram">
-      </div class="col">
+      </div>
     </div>
     <p style="text-align: center">
       <i>Note: a score of -1 in the similarity matrix indicates the comparison was skipped</i>
@@ -37,8 +37,8 @@
   <tr>
   <td style="text-align: center;">
   <p>
-    Test file: <i>{{ code[2] }}</i> (<b>{{ "%.2f"|format(code[0]*100) }}%</b>)<br>
-    Reference file: <i>{{ code[3] }}</i> (<b>{{ "%.2f"|format(code[1]*100) }}%</b>)<br>
+    Test file: <i>{{ code[2]|e }}</i> (<b>{{ "%.2f"|format(code[0]*100) }}%</b>)<br>
+    Reference file: <i>{{ code[3]|e }}</i> (<b>{{ "%.2f"|format(code[1]*100) }}%</b>)<br>
     Token overlap: {{ code[6] }}<br><br>
     <button class="btn btn-secondary" type="button" data-toggle="collapse" data-target="#collapse-{{loop.index}}" aria-expanded="false" aria-controls="collapse-{{loop.index}}">
       View matched code
@@ -48,10 +48,10 @@
     <div class="card card-body">
       <div class="row">
         <div class="col" style="max-width: 600px">
-          <pre><code>{{ code[4] }}</code></pre>
+          <pre><code>{{ code[4]|e }}</code></pre>
         </div>
         <div class="col" style="max-width: 600px">
-          <pre><code>{{ code[5] }}</code></pre>
+          <pre><code>{{ code[5]|e }}</code></pre>
         </div>
       </div>
     </div>

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -115,14 +115,15 @@ def compare_files(file1_data, file2_data):
     if len(slices1[0]) == 0:
         return 0, (0,0), (np.array([]), np.array([]))
 
-    token_overlap = np.sum(slices1[1] - slices1[0])
+    token_overlap1 = np.sum(slices1[1] - slices1[0])
+    token_overlap2 = np.sum(slices2[1] - slices2[0])
 
     if len(file1_data.filtered_code) > 0:
-        similarity1 = token_overlap / len(file1_data.filtered_code)
+        similarity1 = token_overlap1 / len(file1_data.filtered_code)
     else:
         similarity1 = 0
     if len(file2_data.filtered_code) > 0:
-        similarity2 = token_overlap / len(file2_data.filtered_code)
+        similarity2 = token_overlap2 / len(file2_data.filtered_code)
     else:
         similarity2 = 0
 
@@ -135,7 +136,7 @@ def compare_files(file1_data, file2_data):
             np.searchsorted(file2_data.offsets[:,0], slices2),
             0, file2_data.offsets.shape[0] - 1)]
 
-    return token_overlap, (similarity1,similarity2), (slices1,slices2)
+    return token_overlap1, (similarity1,similarity2), (slices1,slices2)
 
 class CopyDetector:
     """Main plagairism detection class. Uses generic functions from


### PR DESCRIPTION
Bug fix: the number of flagged tokens in doc1 should not be used for the doc2 similarity score (if two overlapping n-grams in doc 1 are not overlapping in doc 2, the score will be wrong)
Bug fix: all input code should be escaped before being put on the report!