### PR TITLE
fix/similarity_score

### DIFF
--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -121,11 +121,11 @@ def compare_files(file1_data, file2_data):
     token_overlap2 = np.sum(slices2[1] - slices2[0])
 
     if len(file1_data.filtered_code) > 0:
-        similarity1 = token_overlap1 / len(file1_data.filtered_code)
+        similarity1 = len(idx1) / len(file1_data.hashes)
     else:
         similarity1 = 0
     if len(file2_data.filtered_code) > 0:
-        similarity2 = token_overlap2 / len(file2_data.filtered_code)
+        similarity2 = len(idx2) / len(file2_data.hashes)
     else:
         similarity2 = 0
 

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -26,8 +26,8 @@ class TestTwoFileDetection():
 
         # file order is not guaranteed, so there are two possible
         # similarity matrices depending on the order of the files
-        possible_mtx_1 = np.array([[[-1,-1], [1137/2052,1137/1257]],
-                                  [[1137/1257,1137/2052], [-1,-1]]])
+        possible_mtx_1 = np.array([[[-1, -1], [950/1660, 950/1167]],
+                                  [[950/1167, 950/1660], [-1, -1]]])
         possible_mtx_2 = np.flip(possible_mtx_1, 2)
         assert (np.array_equal(possible_mtx_1, detector.similarity_matrix)
                 or np.array_equal(possible_mtx_2, detector.similarity_matrix))
@@ -51,8 +51,8 @@ class TestTwoFileDetection():
         detector.add_file(TESTS_DIR + "/sample_py/code/sample2.py")
         detector.run()
 
-        assert np.array_equal(np.array([[[-1,-1], [1137/2052,1137/1257]],
-                                        [[1137/1257,1137/2052], [-1,-1]]]),
+        assert np.array_equal(np.array([[[-1, -1], [950/1660, 950/1167]],
+                                        [[950/1167, 950/1660], [-1, -1]]]),
                               detector.similarity_matrix)
         assert np.array_equal(np.array([[-1,1137],[1137,-1]]),
                               detector.token_overlap_matrix)
@@ -127,8 +127,8 @@ class TestTwoFileAPIDetection():
         token_overlap, similarities, slices = compare_files(fp1, fp2)
 
         assert token_overlap == 1137
-        assert similarities[0] == 1137/2052
-        assert similarities[1] == 1137/1257
+        assert similarities[0] == 950/1660
+        assert similarities[1] == 950/1167
 
     def test_compare_boilerplate(self):
         bp_fingerprint = CodeFingerprint(


### PR DESCRIPTION
Change similarity score calculation from "number of overlapping tokens / number of tokens" to "number of overlapping fingerprints / number of fingerprints". This is mostly relevant for files with a larger number of duplicate fingerprints; only unique fingerprints are considered, so if a file has a large amount of duplicated code/text it will be given a lower similarity score than it should.