### PR TITLE
Added fp argument to CodeFingerprint constructor

### DIFF
--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -62,9 +62,12 @@ class CodeFingerprint:
         rather than guessing from the file extension.
     """
     def __init__(self, file, k, win_size, boilerplate=[], filter=True,
-                 language=None):
-        with open(file) as code_fp:
-            code = code_fp.read()
+                 language=None, fp=None):
+        if fp is not None:
+            code = fp.read()
+        else:
+            with open(file) as code_fp:
+                code = code_fp.read()
         if filter:
             filtered_code, offsets = filter_code(code, file, language)
         else:


### PR DESCRIPTION
Now we can specify file-like object to read code from.
It is very useful in cases we can not access file with code by file path
(ex: code stored in database of Automated Assessment Tool).