### PR TITLE
corrected issue causing pairs to appear in output report twice

### DIFF
--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -511,9 +511,14 @@ class CopyDetector:
         x,y = np.where(self.similarity_matrix[:,:,0] > self.display_t)
 
         code_list = []
+        file_pairs = set()
         for idx in range(len(x)):
             test_f = self.test_files[x[idx]]
             ref_f = self.ref_files[y[idx]]
+            if (ref_f, test_f) in file_pairs:
+                # if comparison is already in report, don't add it again
+                continue
+            file_pairs.add((test_f, ref_f))
 
             test_sim = self.similarity_matrix[x[idx], y[idx], 0]
             ref_sim = self.similarity_matrix[x[idx], y[idx], 1]

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -37,8 +37,8 @@ class TestTwoFileDetection():
         html_out = detector.generate_html_report(output_mode="return")
 
         # verify highlighting code isn't being escaped
-        test_str1 = "data[2] = [</span>0<span class='highlight-red'>, 6, 1]"
-        test_str2 = "data[2] = [</span>3<span class='highlight-green'>, 6, 1]"
+        test_str1 = "data[2] = [</span>0<span class='highlight-"
+        test_str2 = "data[2] = [</span>3<span class='highlight-"
         # verify input code is being escaped
         test_str3 = "print(&#34;Incorrect num&#34;"
         assert test_str1 in html_out


### PR DESCRIPTION
Corrected regression introduced between 0.3.0 and 0.4.0. The similarity matrix change could cause files to appear on report twice, once as (a,b), once as (b,a).