### PR TITLE
explicitly use utf-8 encoding when reading

### DIFF
--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -86,7 +86,7 @@ def main():
     args = parser.parse_args()
 
     if args.conf:
-        with open(args.conf) as json_fp:
+        with open(args.conf, encoding="utf-8") as json_fp:
             config = json.load(json_fp)
     elif args.test_dirs:
         if not args.ref_dirs:

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -79,7 +79,7 @@ class CodeFingerprint:
         if fp is not None:
             code = fp.read()
         else:
-            with open(file) as code_fp:
+            with open(file, encoding="utf-8") as code_fp:
                 code = code_fp.read()
         if filter:
             filtered_code, offsets = filter_code(code, file, language)


### PR DESCRIPTION
Opening text files without an explicit encoding scheme may cause issues for operating systems which do not use UTF-8 as the locale encoding (#23, https://peps.python.org/pep-0597/#using-the-default-encoding-is-a-common-mistake). This changes the encoding used by copydetect when reading files to UTF-8.