### PR TITLE
Reduce memory usage of slice matrix

### DIFF
--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -595,8 +595,8 @@ class CopyDetector:
                 slices_test = self.slice_matrix[(x[idx], y[idx])][0]
                 slices_ref = self.slice_matrix[(x[idx], y[idx])][1]
             else:
-                slices_test = self.slice_matrix[(y[idx], x[idx])][0]
-                slices_ref = self.slice_matrix[(y[idx], x[idx])][1]
+                slices_test = self.slice_matrix[(y[idx], x[idx])][1]
+                slices_ref = self.slice_matrix[(y[idx], x[idx])][0]
 
             if self.truncate:
                 truncate = 10

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -528,22 +528,15 @@ class CopyDetector:
                     ref_idx, test_idx = comparisons[(ref_f, test_f)]
                     overlap = self.token_overlap_matrix[ref_idx, test_idx]
                     sim2, sim1 = self.similarity_matrix[ref_idx, test_idx]
-
-                    mtx_key = (ref_idx, test_idx)
-                    if mtx_key in self.slice_matrix:
-                        slices2, slices1 = self.slice_matrix[mtx_key]
-                    else:
-                        # slices not in matrix, so files have no overlap
-                        slices2, slices1 = np.array([]), np.array([])
                 else:
                     overlap, (sim1, sim2), (slices1, slices2) = compare_files(
                         self.file_data[test_f], self.file_data[ref_f]
                     )
                     comparisons[(test_f, ref_f)] = (i, j)
+                    if slices1.shape[0] != 0:
+                        self.slice_matrix[(i, j)] = [slices1, slices2]
 
                 self.similarity_matrix[i, j] = np.array([sim1, sim2])
-                if slices1.shape[0] != 0:
-                    self.slice_matrix[(i, j)] = [slices1, slices2]
                 self.token_overlap_matrix[i, j] = overlap
 
         if not self.silent:
@@ -598,8 +591,12 @@ class CopyDetector:
 
             test_sim = self.similarity_matrix[x[idx], y[idx], 0]
             ref_sim = self.similarity_matrix[x[idx], y[idx], 1]
-            slices_test = self.slice_matrix[(x[idx], y[idx])][0]
-            slices_ref = self.slice_matrix[(x[idx], y[idx])][1]
+            if (x[idx], y[idx]) in self.slice_matrix:
+                slices_test = self.slice_matrix[(x[idx], y[idx])][0]
+                slices_ref = self.slice_matrix[(x[idx], y[idx])][1]
+            else:
+                slices_test = self.slice_matrix[(y[idx], x[idx])][0]
+                slices_ref = self.slice_matrix[(y[idx], x[idx])][1]
 
             if self.truncate:
                 truncate = 10


### PR DESCRIPTION
This PR significantly reduces memory taken up by the slice matrix for very large sets of files, under the assumption that file similarity is typically sparse:

![memory_usage_fix](https://user-images.githubusercontent.com/22311737/216724388-960d22c3-7ae4-4824-bd71-b2f58be35b1d.png)

This is accomplished by converting the slice matrix from an actual NxM matrix (where N is the number of test files and M is the number of reference files) to a dictionary which only stores file similarity when it is greater than 0. Redundant slices are no longer stored (e.g., both A -> B and B -> A are no longer stored as the two are symmetrical).