### PR TITLE
Remove duplicate or erroneous No files found message

### DIFF
--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -409,6 +409,7 @@ class CopyDetector:
         """
         file_list = []
         for dir in dirs:
+            print_warning = True
             for ext in exts:
                 if ext == "*":
                     matched_contents = Path(dir).rglob("*")
@@ -416,9 +417,11 @@ class CopyDetector:
                     matched_contents = Path(dir).rglob("*."+ext.lstrip("."))
                 files = [str(f) for f in matched_contents if f.is_file()]
 
-                if len(files) == 0:
-                    logging.warning("No files found in " + dir)
+                if len(files) > 0:
+                    print_warning = False
                 file_list.extend(files)
+            if print_warning:
+                logging.warning("No files found in " + dir)
 
         # convert to a set to remove duplicates, then back to a list
         return list(set(file_list))


### PR DESCRIPTION
Currently if we allow multiple extensions, e.g., .{c,cpp,h,hpp}, an error is printed for each type not found.
This change will print the message only once and only if no files of any extension were found.