### PR TITLE
improved heatmaps: better links, added groups, added split

### DIFF
--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -86,12 +86,25 @@ def main():
                         default=False, action="store_true",
                         help="save similarity matrix as a CSV file. "
                         "Its name is that of the HTML report "
-                        "with '.csv' extension ")
+                        "with '.csv' extension.")
     parser.add_argument("-P", "--pdf-file", dest="pdf_file",
                         default=False, action="store_true",
                         help="generate a clickable PDF heatmap. "
                         "Its name is that of the HTML report "
-                        "with '.pdf' extension ")
+                        "with '.pdf' extension.")
+    parser.add_argument("-M", "--heatmap-min", dest="hm_minsim",
+                        type=float, default=None, metavar="MIN",
+                        help="simplify PDF heatmaps by discarding rows/cols "
+                        "with only values less than MIN.")
+    parser.add_argument("-G", "--group", dest="hm_groups",
+                        default=[], nargs="+", action="append",
+                        help="split PDF heatmaps into groups, use multiple"
+                        " -G NAME FILE... to specify a group called NAME"
+                        " that contains the given FILEs")
+    parser.add_argument("-S", "--heatmap-split", dest="hm_split",
+                        type=int, default=None, metavar="SIZE",
+                        help="split generated heatmaps into chunks of"
+                        " at most SIZE rows/cols")
     parser.add_argument('--version', action='version',
                         version="copydetect v" + __version__,
                         help="print version number and exit")
@@ -130,7 +143,9 @@ def main():
     detector.run()
     detector.generate_html_report()
     if args.pdf_file :
-        detector.generate_pdf_report()
+        detector.generate_pdf_report(minsim=args.hm_minsim,
+                                     split=args.hm_split,
+                                     groups={g[0] : g[1:] for g in args.hm_groups})
     if args.csv_file :
         detector.generate_csv_report()
 

--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -93,7 +93,7 @@ def main():
                         "Its name is that of the HTML report "
                         "with '.pdf' extension.")
     parser.add_argument("-M", "--heatmap-min", dest="hm_minsim",
-                        type=float, default=None, metavar="MIN",
+                        type=float, default=0.0, metavar="MIN",
                         help="simplify PDF heatmaps by discarding rows/cols "
                         "with only values less than MIN.")
     parser.add_argument("-G", "--group", dest="hm_groups",

--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -140,10 +140,6 @@ def main():
         parser.error("either a path to a configuration file (-c) or a "
                      "list of test directories (-t) must be provided.")
 
-    # get overlapping code
-    detector = CopyDetector.from_config(config)
-    detector.run()
-    detector.generate_html_report()
     if args.pdf_file:
         if not args.hm_groups:
             groups=None
@@ -153,6 +149,12 @@ def main():
             groups = {g[0]: g[1:] for g in args.hm_groups}
         else:
             parser.error("invalid use of -G/--group")
+
+    # get overlapping code
+    detector = CopyDetector.from_config(config)
+    detector.run()
+    detector.generate_html_report()
+    if args.pdf_file:
         detector.generate_pdf_report(minsim=args.hm_minsim,
                                      split=args.hm_split,
                                      groups=groups)

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -850,11 +850,14 @@ class CopyDetector:
             _groups = dict(_groups)
         elif groups == "auto":
             _groups = collections.defaultdict(set)
-            for f in set(self.test_files) | set(self.ref_files):
+            all_files = self.test_files + self.ref_files
+            for f in all_files:
                 b = self.basename(f)
-                g = str(Path(b).parent)
-                if g == "." :
-                    g = b
+                for g in reversed([str(p) for p in Path(b).parents]):
+                    if g != ".":
+                        break
+                else:
+                    g = ""
                 _groups[g].add(b)
             _groups = dict(_groups)
         else:
@@ -881,6 +884,8 @@ class CopyDetector:
             _add(pdf, sns.clustermap(sim, row_colors=rc, col_colors=cc, **kw["sns"]))
             # group heatmaps
             for grp, members in sorted(_groups.items()):
+                if len(members) <= 1:
+                    continue
                 sub = sim[sim.index.isin(members)]
                 if len(sub.index) <= 1:
                     continue


### PR DESCRIPTION
Improved clickable links in PDF heatmap: their size is now more accurately computed to cover the heatmap cell.

Heatmaps can be split in two ways:
 - by size (option `-S`/`--heatmap-size`): a full heatmap is drawn, and then subparts of width/height of at most the given size are extracted and saved separately;
 - by groups (option `-G`/`--group`): groups of files are identified, and a heatmap for each group is generated, presenting only the group's files as its rows.

Another new option `-M`/`--heatmap-min` can be used to set the minimum similarity to keep in generated heatmaps: every row or col that only has values below this is discarded.

The docstrings of the new methods have been improved.