### PR TITLE
FEAT: include test/ref files legend version and execution params/program version

### DIFF
--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -120,7 +120,7 @@ def main():
     # get overlapping code
     detector = CopyDetector.from_config(config)
     detector.run()
-    detector.generate_html_report()
+    detector.generate_html_report(args=vars(args))
 
 if __name__ == "__main__":
     main()

--- a/copydetect/data/report.html
+++ b/copydetect/data/report.html
@@ -18,6 +18,10 @@
     pre {
       text-align: left;
     }
+    .col3 {
+      float: left;
+      width: 33%;
+    }
   </style>
 </head>
 <body>
@@ -37,11 +41,36 @@
     <p style="text-align: center">
       <i>Note: a score of -1 in the similarity matrix indicates the comparison was skipped</i>
     </p>
-    <p>
-    Number of files tested: {{ test_count }}<br>
-    Number of reference files: {{ compare_count }}<br>
-    Test files above display threshold: {{ flagged_file_count }} ({{ "%.2f"|format(flagged_file_count/test_count*100) }}%)<br><br>
-    </p>
+
+    <div class="row" style="font-size: small;">
+      <div class="col3">
+        <b>Number of files tested (vertical):</b> {{ test_count }}, 
+        <b>above threshold:</b> {{ flagged_file_count }} ({{ "%.2f"|format(flagged_file_count/test_count*100) }}%)
+        <ul>
+          {%- for file in test_files %}
+            <li>{{ loop.index0 }}={{ file }}</li> 
+          {% endfor -%}
+        </ul>
+      </div>
+      <div class="col3">
+        <b>Number of reference files (horizontal):</b> {{ compare_count }}
+        <ul>
+          {%- for file in compare_files %}
+            <li>{{ loop.index0 }}={{ file }}</li> 
+          {% endfor -%}
+        </ul>
+      </div>
+      <div class="col3">
+        <b>Execution params (see <code>copydetect --help</code>):</b>
+        <ul>
+          <li><b>version:</b> {{ version }}</li>
+          {%- for key, value in args.items() %}
+            <li><b>{{ key }}:</b> {{ value }}</li> 
+          {% endfor -%}
+        <ul>
+      </div>
+    </div>
+
 
   <h2>Matched Code</h2>
   <table class="table table-striped table-sm">

--- a/copydetect/data/report.html
+++ b/copydetect/data/report.html
@@ -44,30 +44,51 @@
 
     <div class="row" style="font-size: small;">
       <div class="col3">
-        <b>Number of files tested (vertical):</b> {{ test_count }}, 
-        <b>above threshold:</b> {{ flagged_file_count }} ({{ "%.2f"|format(flagged_file_count/test_count*100) }}%)
-        <ul>
-          {%- for file in test_files %}
-            <li>{{ loop.index0 }}={{ file }}</li> 
-          {% endfor -%}
-        </ul>
+        <p>
+          <b>Number of files tested (vertical):</b> {{ test_count }}, 
+          <b>above threshold:</b> {{ flagged_file_count }} ({{ "%.2f"|format(flagged_file_count/test_count*100) }}%)<br><br>
+          <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-test-files" aria-expanded="false" aria-controls="collapse-test-files">
+            View <i>test</i> files
+          </button>
+        </p>
+        <div class="collapse" id="collapse-test-files">
+          <ul>
+            {%- for file in test_files %}
+              <li>{{ loop.index0 }}={{ file }}</li> 
+            {% endfor -%}
+          </ul>
+        </div>
       </div>
       <div class="col3">
-        <b>Number of reference files (horizontal):</b> {{ compare_count }}
-        <ul>
-          {%- for file in compare_files %}
-            <li>{{ loop.index0 }}={{ file }}</li> 
-          {% endfor -%}
-        </ul>
+        <p>
+          <b>Number of reference files (horizontal):</b> {{ compare_count }}<br><br>
+          <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-reference-files" aria-expanded="false" aria-controls="collapse-reference-files">
+            View <i>reference</i> files
+          </button>
+        </p>
+        <div class="collapse" id="collapse-reference-files">
+          <ul>
+            {%- for file in compare_files %}
+              <li>{{ loop.index0 }}={{ file }}</li> 
+            {% endfor -%}
+          </ul>
+        </div>
       </div>
       <div class="col3">
-        <b>Execution params (see <code>copydetect --help</code>):</b>
-        <ul>
-          <li><b>version:</b> {{ version }}</li>
-          {%- for key, value in args.items() %}
-            <li><b>{{ key }}:</b> {{ value }}</li> 
-          {% endfor -%}
-        <ul>
+        <p>
+          <b>Execution params (see <code>copydetect --help</code>):</b><br><br>
+          <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-exec-params" aria-expanded="false" aria-controls="collapse-exec-params">
+            View execution parameters
+          </button>
+        </p>
+        <div class="collapse" id="collapse-exec-params">
+          <ul>
+            <li><b>version:</b> {{ version }}</li>
+            {%- for key, value in args.items() %}
+              <li><b>{{ key }}:</b> {{ value }}</li> 
+            {% endfor -%}
+          <ul>
+        </div>
       </div>
     </div>
 

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -20,6 +20,7 @@ from jinja2 import Template
 from .utils import (filter_code, highlight_overlap, get_copied_slices,
                     get_document_fingerprints, find_fingerprint_overlap,
                     get_token_coverage)
+from . import __version__
 from . import defaults
 
 class CodeFingerprint:
@@ -649,7 +650,7 @@ class CopyDetector:
         code_list.sort(key=lambda x: -x[0])
         return code_list
 
-    def generate_html_report(self, output_mode="save"):
+    def generate_html_report(self, output_mode="save", args={}):
         """Generates an html report listing all files with similarity
         above the display_threshold, with the copied code segments
         highlighted.
@@ -660,6 +661,9 @@ class CopyDetector:
             If "save", the output will be saved to the file specified
             by self.out_file. If "return", the output HTML will be
             directly returned by this function.
+        args : dict
+            CLI args to include them in the report.
+
         """
         if len(self.similarity_matrix) == 0:
             logging.error("Cannot generate report: no files compared")
@@ -695,8 +699,12 @@ class CopyDetector:
         flagged = self.similarity_matrix[:,:,0] > self.display_t
         flagged_file_count = np.sum(np.any(flagged, axis=1))
 
-        output = template.render(test_count=len(self.test_files),
+        output = template.render(args=args,
+                                 version=__version__,
+                                 test_count=len(self.test_files),
+                                 test_files=self.test_files,
                                  compare_count=len(self.ref_files),
+                                 compare_files=self.ref_files,
                                  flagged_file_count=flagged_file_count,
                                  code_list=code_list,
                                  sim_mtx_base64=sim_mtx_base64,


### PR DESCRIPTION
FIX #45 to include execution params, usefull when comparing runs, 
but also include a list of all files compared, to explain which file each number in the matrix refers to.

All 3 new sections are collapsible ( file-lists may be very long) and rendered as 3-columns side-by-side.
![image](https://github.com/blingenf/copydetect/assets/501585/83c374ef-9f61-4b1c-afc1-07abbefdc34d)
