### PR TITLE
Feature/config reorg

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
         include:
           - os: ubuntu-20.04
-            python-version: "3.6"
+            python-version: "3.7"
           - os: macos-latest
             python-version: "3.9"
           - os: windows-latest

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Copydetect is a code plagiarism detection tool based on the approach proposed in
 Note that, like MOSS, copydetect is designed to detect likely instances of plagiarism; it is not guaranteed to catch cheaters dedicated to evading it, and it does not provide a guarantee that plagiarism has occurred.
 
 ## Installation
-Copydetect can be installed using `pip install copydetect`. Note that Python version 3.6 or greater is required. You can then generate a report using the `copydetect` command (`copydetect.exe` on Windows. If your scripts folder is not in your PATH the code can also be run using `py.exe -m copydetect`).
+Copydetect can be installed using `pip install copydetect`. Note that Python version 3.7 or greater is required. You can then generate a report using the `copydetect` command (`copydetect.exe` on Windows. If your scripts folder is not in your PATH the code can also be run using `py.exe -m copydetect`).
 
 ## Usage
 The simplest usage is `copydetect -t DIRS`, where DIRS is a space-separated list of directories to search for input files. This will recursively search for all files in the provided directories and compare every file with every other file. To look only at specific file extensions, use `-e` followed by another space-separated list (for example, `copydetect -t student_code -e cc cpp h`)

--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -120,7 +120,7 @@ def main():
     # get overlapping code
     detector = CopyDetector.from_config(config)
     detector.run()
-    detector.generate_html_report(args=vars(args))
+    detector.generate_html_report()
 
 if __name__ == "__main__":
     main()

--- a/copydetect/_config.py
+++ b/copydetect/_config.py
@@ -1,0 +1,138 @@
+from dataclasses import dataclass, field, asdict
+from typing import Optional, List, Dict, ClassVar
+from pathlib import Path
+
+from copydetect import defaults
+
+
+@dataclass
+class CopydetectConfig:
+    """Utility class for providing a full list of configuration
+    parameters with type/value checking and simple conversion to and from
+    the JSON format used by the copydetect CLI.
+    """
+
+    test_dirs: List[str] = field(default_factory=lambda: [])
+    ref_dirs: Optional[List[str]] = field(default_factory=lambda: [])
+    boilerplate_dirs: Optional[List[str]] = field(default_factory=lambda: [])
+    extensions: Optional[List[str]] = field(default_factory=lambda: ["*"])
+    noise_t: int = defaults.NOISE_THRESHOLD
+    guarantee_t: int = defaults.GUARANTEE_THRESHOLD
+    display_t: float = defaults.DISPLAY_THRESHOLD
+    same_name_only: bool = False
+    ignore_leaf: bool = False
+    autoopen: bool = True
+    disable_filtering: bool = False
+    force_language: Optional[str] = None
+    truncate: bool = False
+    out_file: str = "./report.html"
+    silent: bool = False
+    encoding: str = "utf-8"
+
+    window_size: int = field(init=False, default=guarantee_t - noise_t + 1)
+    short_names: ClassVar[Dict[str, str]] = {
+        "noise_threshold": "noise_t",
+        "guarantee_threshold": "guarantee_t",
+        "display_threshold": "display_t",
+        "test_directories": "test_dirs",
+        "reference_directories": "ref_dirs",
+        "boilerplate_directories": "boilerplate_dirs",
+    }
+
+    def _check_arguments(self):
+        """Checks type/value of all parameters"""
+        if not isinstance(self.test_dirs, list):
+            raise TypeError("Test directories must be a list")
+        if not isinstance(self.ref_dirs, list):
+            raise TypeError("Reference directories must be a list")
+        if not isinstance(self.extensions, list):
+            raise TypeError("extensions must be a list")
+        if not isinstance(self.boilerplate_dirs, list):
+            raise TypeError("Boilerplate directories must be a list")
+        if not isinstance(self.same_name_only, bool):
+            raise TypeError("same_name_only must be true or false")
+        if not isinstance(self.ignore_leaf, bool):
+            raise TypeError("ignore_leaf must be true or false")
+        if not isinstance(self.disable_filtering, bool):
+            raise TypeError("disable_filtering must be true or false")
+        if not isinstance(self.autoopen, bool):
+            raise TypeError("disable_autoopen must be true or false")
+        if self.force_language is not None:
+            if not isinstance(self.force_language, str):
+                raise TypeError("force_language must be a string")
+        if not isinstance(self.truncate, bool):
+            raise TypeError("truncate must be true or false")
+        if not isinstance(self.noise_t, int):
+            if int(self.noise_t) == self.noise_t:
+                self.noise_t = int(self.noise_t)
+                self.window_size = int(self.window_size)
+            else:
+                raise TypeError("Noise threshold must be an integer")
+        if not isinstance(self.guarantee_t, int):
+            if int(self.guarantee_t) == self.guarantee_t:
+                self.guarantee_t = int(self.guarantee_t)
+                self.window_size = int(self.window_size)
+            else:
+                raise TypeError("Guarantee threshold must be an integer")
+
+        # value checking
+        if self.guarantee_t < self.noise_t:
+            raise ValueError(
+                "Guarantee threshold must be greater than or "
+                "equal to noise threshold"
+            )
+        if self.display_t > 1 or self.display_t < 0:
+            raise ValueError("Display threshold must be between 0 and 1")
+        if not Path(self.out_file).parent.exists():
+            raise ValueError(
+                "Invalid output file path (directory does not exist)"
+            )
+
+    @staticmethod
+    def normalize_outfile(file_path: str) -> str:
+        """Ensures that the outfile has an html suffix. If the provided
+        out file is a directory, append report.html to the path.
+        """
+        out_path = Path(file_path)
+        if out_path.is_dir():
+            file_path += "/report.html"
+        elif out_path.suffix != ".html":
+            file_path = str(out_path) + ".html"
+        return str(file_path)
+
+    def to_json(self) -> dict:
+        """Converts the parameters of this configuration to the JSON
+        format used for copydetect config files
+        """
+        dict_params = asdict(self)
+        for long_name, short_name in self.short_names.items():
+            dict_params[long_name] = dict_params[short_name]
+            del dict_params[short_name]
+        dict_params["disable_autoopen"] = not dict_params["autoopen"]
+        del dict_params["autoopen"]
+        if self.force_language is None:
+            del dict_params["force_language"]
+        return dict_params
+
+    @staticmethod
+    def normalize_json(config: dict) -> dict:
+        """Converts the longer names used by the JSON configuration
+        format to the arguments used by the CopyDetector class.
+        """
+        for long_name, short_name in CopydetectConfig.short_names.items():
+            if long_name in config:
+                config[short_name] = config[long_name]
+                del config[long_name]
+        if "disable_autoopen" in config:
+            config["autoopen"] = not config["disable_autoopen"]
+            del config["disable_autoopen"]
+        return config
+
+    def __post_init__(self):
+        """Sets reference directories to test directories if needed and
+        performs argument checking.
+        """
+        if len(self.ref_dirs) == 0:
+            self.ref_dirs = self.test_dirs
+        self.out_file = self.normalize_outfile(self.out_file)
+        self._check_arguments()

--- a/copydetect/data/report.html
+++ b/copydetect/data/report.html
@@ -22,6 +22,10 @@
       float: left;
       width: 33%;
     }
+    .file-info-list {
+      max-height: 900px;
+      overflow-y: scroll;
+    }
   </style>
 </head>
 <body>
@@ -45,14 +49,14 @@
     <div class="row" style="font-size: small;">
       <div class="col3">
         <p>
-          <b>Number of files tested (vertical):</b> {{ test_count }}, 
-          <b>above threshold:</b> {{ flagged_file_count }} ({{ "%.2f"|format(flagged_file_count/test_count*100) }}%)<br><br>
+          <b>Number of files tested (vertical):</b> {{ test_count }}<br>
+          <b>Number above display threshold:</b> {{ flagged_file_count }} ({{ "%.2f"|format(flagged_file_count/test_count*100) }}%)<br><br>
           <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-test-files" aria-expanded="false" aria-controls="collapse-test-files">
             View <i>test</i> files
           </button>
         </p>
         <div class="collapse" id="collapse-test-files">
-          <ul>
+          <ul class="file-info-list">
             {%- for file in test_files %}
               <li>{{ loop.index0 }}={{ file }}</li> 
             {% endfor -%}
@@ -61,13 +65,13 @@
       </div>
       <div class="col3">
         <p>
-          <b>Number of reference files (horizontal):</b> {{ compare_count }}<br><br>
+          <b>Number of reference files (horizontal):</b> {{ compare_count }}<br><br><br>
           <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-reference-files" aria-expanded="false" aria-controls="collapse-reference-files">
             View <i>reference</i> files
           </button>
         </p>
         <div class="collapse" id="collapse-reference-files">
-          <ul>
+          <ul class="file-info-list">
             {%- for file in compare_files %}
               <li>{{ loop.index0 }}={{ file }}</li> 
             {% endfor -%}
@@ -76,18 +80,15 @@
       </div>
       <div class="col3">
         <p>
-          <b>Execution params (see <code>copydetect --help</code>):</b><br><br>
+          <b>Execution params (see <code>copydetect --help</code>):</b><br><br><br>
           <button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-exec-params" aria-expanded="false" aria-controls="collapse-exec-params">
             View execution parameters
           </button>
         </p>
         <div class="collapse" id="collapse-exec-params">
-          <ul>
-            <li><b>version:</b> {{ version }}</li>
-            {%- for key, value in args.items() %}
-              <li><b>{{ key }}:</b> {{ value }}</li> 
-            {% endfor -%}
-          <ul>
+          <b>version:</b> {{ version }}<br>
+          <b>Configuration:</b>
+          <pre class="file-info-list">{{config_params}}</pre>
         </div>
       </div>
     </div>

--- a/copydetect/utils.py
+++ b/copydetect/utils.py
@@ -127,12 +127,14 @@ def get_copied_slices(idx, k):
 
     return np.array([slice_starts, slice_ends])
 
-def get_document_fingerprints(doc, k, window_size, boilerplate=[]):
+def get_document_fingerprints(doc, k, window_size, boilerplate=None):
     """Given a document, computes all k-gram hashes and uses the
     winnowing algorithm to reduce their number. Optionally takes a
     list of boilerplate hashes to remove from the winnowed list.
     Returns the selected hashes and their indexes in the original list
     """
+    if boilerplate is None:
+        boilerplate = []
     hashes, idx = winnow(hashed_kgrams(doc, k=k), window_size=window_size)
     if len(boilerplate) > 0:
         _, overlap_idx, _ = np.intersect1d(hashes, boilerplate,

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,10 @@ setup(name="copydetect",
                              optional=True)],
       install_requires=["numpy", "matplotlib", "jinja2", "pygments", "tqdm"],
       package_data={"copydetect" : ["data/*"]},
-      python_requires=">=3.6",
+      python_requires=">=3.7",
       entry_points={"console_scripts" : [
           "copydetect = copydetect.__main__:main"]},
       classifiers=[
-          "Programming Language :: Python :: 3.6",
           "Programming Language :: Python :: 3.7",
           "Programming Language :: Python :: 3.8",
           "Programming Language :: Python :: 3.9",

--- a/tests/test_detector.py
+++ b/tests/test_detector.py
@@ -14,14 +14,15 @@ class TestTwoFileDetection():
     """
     def test_compare(self):
         config = {
-          "test_directories" : [TESTS_DIR + "/sample_py/code"],
-          "reference_directories" : [TESTS_DIR + "/sample_py/code"],
-          "extensions" : ["py"],
-          "noise_threshold" : 25,
-          "guarantee_threshold" : 25,
-          "display_threshold" : 0
+            "test_directories" : [TESTS_DIR + "/sample_py/code"],
+            "reference_directories" : [TESTS_DIR + "/sample_py/code"],
+            "extensions" : ["py"],
+            "noise_threshold" : 25,
+            "guarantee_threshold" : 25,
+            "display_threshold" : 0,
+            "silent" : True
         }
-        detector = CopyDetector(config, silent=True)
+        detector = CopyDetector.from_config(config)
         detector.run()
 
         # file order is not guaranteed, so there are two possible
@@ -59,16 +60,17 @@ class TestTwoFileDetection():
 
     def test_compare_saving(self, tmpdir):
         config = {
-          "test_directories" : [TESTS_DIR + "/sample_py/code"],
-          "reference_directories" : [TESTS_DIR + "/sample_py/code"],
-          "extensions" : ["py"],
-          "noise_threshold" : 25,
-          "guarantee_threshold" : 25,
-          "display_threshold" : 0,
-          "disable_autoopen" : True,
-          "out_file" : tmpdir
+            "test_directories" : [TESTS_DIR + "/sample_py/code"],
+            "reference_directories" : [TESTS_DIR + "/sample_py/code"],
+            "extensions" : ["py"],
+            "noise_threshold" : 25,
+            "guarantee_threshold" : 25,
+            "display_threshold" : 0,
+            "disable_autoopen" : True,
+            "out_file" : tmpdir,
+            "silent" : True
         }
-        detector = CopyDetector(config, silent=True)
+        detector = CopyDetector.from_config(config)
         detector.run()
         detector.generate_html_report()
 
@@ -77,15 +79,16 @@ class TestTwoFileDetection():
 
     def test_compare_boilerplate(self):
         config = {
-          "test_directories" : [TESTS_DIR + "/sample_py/code"],
-          "reference_directories" : [TESTS_DIR + "/sample_py/code"],
-          "boilerplate_directories" : [TESTS_DIR + "/sample_py/boilerplate"],
-          "extensions" : ["py"],
-          "noise_threshold" : 25,
-          "guarantee_threshold" : 25,
-          "display_threshold" : 0
+            "test_directories" : [TESTS_DIR + "/sample_py/code"],
+            "reference_directories" : [TESTS_DIR + "/sample_py/code"],
+            "boilerplate_directories" : [TESTS_DIR + "/sample_py/boilerplate"],
+            "extensions" : ["py"],
+            "noise_threshold" : 25,
+            "guarantee_threshold" : 25,
+            "display_threshold" : 0,
+            "silent": True
         }
-        detector = CopyDetector(config, silent=True)
+        detector = CopyDetector.from_config(config)
         detector.run()
 
         assert np.array_equal(np.array([[[-1,-1],[0,0]],[[0,0],[-1,-1]]]),
@@ -98,16 +101,17 @@ class TestTwoFileDetection():
         and perform some basic sanity checking.
         """
         config = {
-          "test_directories" : [TESTS_DIR],
-          "reference_directories" : [TESTS_DIR],
-          "extensions" : ["*"],
-          "noise_threshold" : 25,
-          "guarantee_threshold" : 30,
-          "display_threshold" : 0.3,
-          "disable_autoopen" : True,
-          "out_file" : tmpdir
+            "test_directories" : [TESTS_DIR],
+            "reference_directories" : [TESTS_DIR],
+            "extensions" : ["*"],
+            "noise_threshold" : 25,
+            "guarantee_threshold" : 30,
+            "display_threshold" : 0.3,
+            "disable_autoopen" : True,
+            "out_file" : tmpdir,
+            "silent": True
         }
-        detector = CopyDetector(config, silent=True)
+        detector = CopyDetector.from_config(config)
         detector.run()
         html_out = detector.generate_html_report()
 


### PR DESCRIPTION
This PR organizes parameter management and type/value checking for the `CopyDetector` class into a dataclass object. It also removes the `config` argument to `CopyDetector`, which has been deprecated since version 0.4.1. This also allows the configuration options used to instantiate the class to be conveniently output on the html report.

Note that a consequence of this refactor several member variables of `CopyDetector` are now stored in the conf object (e.g., `self.noise_t` --> `self.conf.noise_t`). These were never documented in the API so I'm not adding a deprecation warning, but some code may break. Support for python 3.6 is also dropped.

