### PR TITLE
Improved duplicate hash handling

### DIFF
--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -67,9 +67,9 @@ class CodeFingerprint:
         in the filtered code to locations in the unfiltered code.
     hashes : 1D array of ints
         List of fingerprints extracted from the filtered code.
-    hash_idx : 1D array of ints
-        List of indexes of the selected fingerprints. Used for
-        translating hash indexes to indexes in the filtered code.
+    hash_idx : Dict[int, NDArray[int]]
+        Mapping of each fingerprint hash back to all indexes in the
+        original code in which this fingerprint appeared.
     k : int
         Value of provided k argument.
     language : str
@@ -77,8 +77,8 @@ class CodeFingerprint:
         rather than guessing from the file extension.
     token_coverage : int
         The number of tokens in the tokenized code which are considered
-        for fingerprint comparison, after dropping duplicate k-grams and
-        performing winnowing.
+        for fingerprint comparison, after performing winnowing and
+        removing boilerplate.
     """
     def __init__(self, file, k, win_size, boilerplate=None, filter=True,
                  language=None, fp=None, encoding: str = "utf-8"):

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -65,8 +65,8 @@ class CodeFingerprint:
         The cumulative number of characters removed during filtering at
         each index of the filtered code. Used for translating locations
         in the filtered code to locations in the unfiltered code.
-    hashes : 1D array of ints
-        List of fingerprints extracted from the filtered code.
+    hashes : Set[int]
+        Set of fingerprint hashes extracted from the filtered code.
     hash_idx : Dict[int, List[int]]
         Mapping of each fingerprint hash back to all indexes in the
         original code in which this fingerprint appeared.

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -67,7 +67,7 @@ class CodeFingerprint:
         in the filtered code to locations in the unfiltered code.
     hashes : 1D array of ints
         List of fingerprints extracted from the filtered code.
-    hash_idx : Dict[int, NDArray[int]]
+    hash_idx : Dict[int, List[int]]
         Mapping of each fingerprint hash back to all indexes in the
         original code in which this fingerprint appeared.
     k : int

--- a/copydetect/utils.py
+++ b/copydetect/utils.py
@@ -5,6 +5,7 @@ documents.
 
 import logging
 import warnings
+from typing import Dict, List
 
 from pygments import lexers, token
 import pygments.util
@@ -220,7 +221,7 @@ def highlight_overlap(doc, slices, left_hl, right_hl,
 
     return new_doc, hl_percent
 
-def get_token_coverage(idx, k, token_len):
+def get_token_coverage(idx: Dict[int, List[int]], k: int, token_len: int):
     """Determines the number of tokens in the original document which
     are included in the winnowed indices
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,7 +175,7 @@ class TestTokenizerOtherSamples():
 
     def test_get_token_coverage(self):
         sample = "0123456789"
-        idx1 = np.array([0, 5])
+        idx1 = {0: [0], 1: [5]}
 
         # two 5-grams starting at 0 and 5 cover all 10 tokens
         assert cd.get_token_coverage(idx1, 5, len(sample)) == len(sample)
@@ -187,5 +187,5 @@ class TestTokenizerOtherSamples():
         assert cd.get_token_coverage(idx1, 1, len(sample)) == 2
 
         # k-gram overlap shouldn't matter
-        idx = np.arange(8)
+        idx = {i: [i] for i in range(8)}
         assert cd.get_token_coverage(idx, 3, len(sample)) == len(sample)


### PR DESCRIPTION
This PR changes the `hash_idx` object in CodeFingerprint from a 1d array of unique hash indexes to a dictionary mapping all hashes to a list of indexes they appear in the code at. The `hashes` variable has been changed from an array of integers to a simple python set; numpy isn't designed for sets, so a simple python set intersection is more efficient than numpy's `intersect1d`.

This makes the code highlighting a bit more intuitive (if there are duplicate sections in a file both will be highlighted rather than just the first occurrence). It also means that file similarity metric has been changed from
`overlapping tokens after removing duplicate fingerprints/number of tokens in unique fingerprints`
to the more directly interpretable
`overlapping tokens/total token count`
Note that the old calculation method still applies if the guarantee threshold is higher than the noise threshold or there are boilerplate files -- similarity is only measured over the tokens which are actually compared.

Fixes #34 