### PR TITLE
New option: Link css files from within report.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Configuration options can be provided either by using the command line arguments
 - `out_file` (`-O`, `--out-file`): path to save output report to. A '.html' extension will be added to the path if not provided. If a directory is provided instead of a file, the report will be saved to that directory as report.html.
 - `encoding` (`--encoding`): encoding to use for reading files (the default is UTF-8). If files use varying encodings, --encoding DETECT can be used to detect the encoding of all files *(note: encoding detection requires the chardet package)*.
 
+Advanced options:
+
+- `css` (`--css`): Optional list of CSS files that will be linked in the generated HTML report file. These will overwrite the styling of the default report.
+
 ## API
 Copydetect can also be run via the python API. An example of basic usage is provided below. API documentation is available [here](https://copydetect.readthedocs.io/en/latest/api.html).
 ```

--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -80,6 +80,10 @@ def main():
                         "If a directory is provided instead of a file, the "
                         "report will be saved  to that directory as "
                         "report.html.")
+    parser.add_argument("-C", '--css', nargs="+",
+                        metavar="CSS-FILE", default=[], dest="css_files",
+                        help="List of CSS files that will be linked in the "
+                        "generated HTML report file.")
     parser.add_argument('--version', action='version',
                         version="copydetect v" + __version__,
                         help="print version number and exit")
@@ -111,6 +115,7 @@ def main():
           "disable_autoopen" : args.autoopen,
           "truncate" : args.truncate,
           "out_file" : args.out_file,
+          "css_files": args.css_files,
           "encoding": args.encoding,
         }
     else:

--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -80,10 +80,11 @@ def main():
                         "If a directory is provided instead of a file, the "
                         "report will be saved  to that directory as "
                         "report.html.")
-    parser.add_argument("-C", '--css', nargs="+",
+    parser.add_argument('--css', nargs="+",
                         metavar="CSS-FILE", default=[], dest="css_files",
-                        help="List of CSS files that will be linked in the "
-                        "generated HTML report file.")
+                        help="Optional list of CSS files that will be linked "
+                        "in the generated HTML report file. These will "
+                        "overwrite the styling of the default report.")
     parser.add_argument('--version', action='version',
                         version="copydetect v" + __version__,
                         help="print version number and exit")

--- a/copydetect/_config.py
+++ b/copydetect/_config.py
@@ -26,7 +26,7 @@ class CopydetectConfig:
     force_language: Optional[str] = None
     truncate: bool = False
     out_file: str = "./report.html"
-    linked_css: List[str] = field(default_factory=lambda: [])
+    css_files: List[str] = field(default_factory=lambda: [])
     silent: bool = False
     encoding: str = "utf-8"
 
@@ -75,7 +75,7 @@ class CopydetectConfig:
                 self.window_size = int(self.window_size)
             else:
                 raise TypeError("Guarantee threshold must be an integer")
-        if not isinstance(self.linked_css, list):
+        if not isinstance(self.css_files, list):
             raise TypeError("Linked CSS entries must be a list")
         
         # value checking

--- a/copydetect/_config.py
+++ b/copydetect/_config.py
@@ -26,6 +26,7 @@ class CopydetectConfig:
     force_language: Optional[str] = None
     truncate: bool = False
     out_file: str = "./report.html"
+    linked_css: List[str] = field(default_factory=lambda: [])
     silent: bool = False
     encoding: str = "utf-8"
 
@@ -74,7 +75,9 @@ class CopydetectConfig:
                 self.window_size = int(self.window_size)
             else:
                 raise TypeError("Guarantee threshold must be an integer")
-
+        if not isinstance(self.linked_css, list):
+            raise TypeError("Linked CSS entries must be a list")
+        
         # value checking
         if self.guarantee_t < self.noise_t:
             raise ValueError(

--- a/copydetect/data/report.html
+++ b/copydetect/data/report.html
@@ -6,7 +6,7 @@
     <title>Copy Detection Report</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-uWxY/CJNBR+1zjPWmfnSnVxwRheevXITnMqoEIeG1LJrdI0GlVs/9cVSyPYXdcSF" crossorigin="anonymous">
 
-  {%- for css in linked_css %}
+  {%- for css in css_files %}
   <link href="{{ css }}" rel="stylesheet">
   {% endfor -%}
 

--- a/copydetect/data/report.html
+++ b/copydetect/data/report.html
@@ -5,6 +5,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Copy Detection Report</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-uWxY/CJNBR+1zjPWmfnSnVxwRheevXITnMqoEIeG1LJrdI0GlVs/9cVSyPYXdcSF" crossorigin="anonymous">
+
+  {%- for css in linked_css %}
+  <link href="{{ css }}" rel="stylesheet">
+  {% endfor -%}
+
   <style>
     h1 {
       text-align: center;
@@ -29,7 +34,7 @@
   </style>
 </head>
 <body>
-<div class="container" style="margin-top: 3em; max-width: 1400px">
+<div class="container" style="margin-top: 3em;">
   <h1 style="margin-bottom: 1em;">Copy Detection Report</h1>
   <h2>Overview</h2>
     <div class="container d-flex justify-content-center">
@@ -111,7 +116,7 @@
   <div class="collapse" id="collapse-{{loop.index}}">
     <div class="card card-body">
       <div class="row">
-        <div class="col" style="max-width: 600px">
+        <div class="col">
           <pre><code>{{ code[4] }}</code></pre>
         </div>
         <div class="col" style="max-width: 600px">

--- a/copydetect/data/report.html
+++ b/copydetect/data/report.html
@@ -6,10 +6,6 @@
     <title>Copy Detection Report</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-uWxY/CJNBR+1zjPWmfnSnVxwRheevXITnMqoEIeG1LJrdI0GlVs/9cVSyPYXdcSF" crossorigin="anonymous">
 
-  {%- for css in css_files %}
-  <link href="{{ css }}" rel="stylesheet">
-  {% endfor -%}
-
   <style>
     h1 {
       text-align: center;
@@ -31,10 +27,22 @@
       max-height: 900px;
       overflow-y: scroll;
     }
+    .main-report-div {
+      margin-top: 3em;
+      max-width: 1400px;
+    }
+    .code-display {
+      max-width: 600px
+    }
   </style>
+
+  {%- for css in css_files %}
+    <link href="{{ css }}" rel="stylesheet">
+  {% endfor -%}
+
 </head>
 <body>
-<div class="container" style="margin-top: 3em;">
+<div class="container main-report-div">
   <h1 style="margin-bottom: 1em;">Copy Detection Report</h1>
   <h2>Overview</h2>
     <div class="container d-flex justify-content-center">
@@ -116,10 +124,10 @@
   <div class="collapse" id="collapse-{{loop.index}}">
     <div class="card card-body">
       <div class="row">
-        <div class="col">
+        <div class="col code-display">
           <pre><code>{{ code[4] }}</code></pre>
         </div>
-        <div class="col" style="max-width: 600px">
+        <div class="col code-display">
           <pre><code>{{ code[5] }}</code></pre>
         </div>
       </div>

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -237,7 +237,7 @@ class CopyDetector:
         highlighted regions from the displayed output
     out_file : str
         Path to output report file.
-    linked_css: list
+    css_files: list
         List of css files that will be linked within the generated html report
     silent : bool
         If true, all logging output will be supressed.
@@ -253,7 +253,7 @@ class CopyDetector:
                  display_t=defaults.DISPLAY_THRESHOLD,
                  same_name_only=False, ignore_leaf=False, autoopen=True,
                  disable_filtering=False, force_language=None,
-                 truncate=False, out_file="./report.html", linked_css=None,
+                 truncate=False, out_file="./report.html", css_files=None,
                  silent=False, encoding: str = "utf-8"):
         conf_args = locals()
         conf_args = {
@@ -572,7 +572,7 @@ class CopyDetector:
 
         formatted_conf = json.dumps(self.conf.to_json(), indent=4)
         output = template.render(config_params=formatted_conf,
-                                 linked_css=self.conf.linked_css,
+                                 css_files=self.conf.css_files,
                                  version=__version__,
                                  test_count=len(self.test_files),
                                  test_files=self.test_files,

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -237,6 +237,8 @@ class CopyDetector:
         highlighted regions from the displayed output
     out_file : str
         Path to output report file.
+    linked_css: list
+        List of css files that will be linked within the generated html report
     silent : bool
         If true, all logging output will be supressed.
     encoding : str, default="utf-8"
@@ -251,8 +253,8 @@ class CopyDetector:
                  display_t=defaults.DISPLAY_THRESHOLD,
                  same_name_only=False, ignore_leaf=False, autoopen=True,
                  disable_filtering=False, force_language=None,
-                 truncate=False, out_file="./report.html", silent=False,
-                 encoding: str = "utf-8"):
+                 truncate=False, out_file="./report.html", linked_css=None,
+                 silent=False, encoding: str = "utf-8"):
         conf_args = locals()
         conf_args = {
             key: val
@@ -570,6 +572,7 @@ class CopyDetector:
 
         formatted_conf = json.dumps(self.conf.to_json(), indent=4)
         output = template.render(config_params=formatted_conf,
+                                 linked_css=self.conf.linked_css,
                                  version=__version__,
                                  test_count=len(self.test_files),
                                  test_files=self.test_files,

--- a/docs/cmdline.rst
+++ b/docs/cmdline.rst
@@ -33,3 +33,7 @@ Configuration options can be provided either by using the command line arguments
 - ``truncate`` (``-T``, ``--truncate``):  if ``true``, highlighted code will be truncated to remove non-highlighted regions from the displayed output (sections not within 10 lines of highlighted code will be replaced with "...").
 - ``out_file`` (``-O``, ``--out-file``): path to save output report to. A '.html' extension will be added to the path if not provided. If a directory is provided instead of a file, the report will be saved to that directory as report.html.
 - ``encoding`` (``--encoding``): encoding to use for reading files (the default is UTF-8). If files use varying encodings, --encoding DETECT can be used to detect the encoding of all files *(note: encoding detection requires the chardet package)*.
+
+Advanced options:
+
+- ``css`` (``--css``): Optional list of CSS files that will be linked in the generated HTML report file. These will overwrite the styling of the default report.


### PR DESCRIPTION
Just messing around and I hope this will be useful. I've added an option to my fork that allows the user to specify a list of CSS files that will be linked from the generated *report.html* file, and removed a couple static styles from the html.

For me personally, I needed to increased the max-width of the code columns via css and add a custom tab size, so I could see both sets of code clearly. I hope these commits will allow more flexibility for end users to customize the report how they wish.