### PR TITLE
Separated creation of CodeFingerprints and comparision of fingerprints

### DIFF
--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -393,10 +393,6 @@ class CopyDetector:
         locations of copied code are stored in slice_matrix and
         token_overlap_matrix, respectively.
         """
-        start_time = time.time()
-        if not self.conf.silent:
-            print("  0.00: Generating file fingerprints")
-        self._preprocess_code(self.test_files + self.ref_files)
 
         self.similarity_matrix = np.full(
             (len(self.test_files), len(self.ref_files), 2),
@@ -407,9 +403,6 @@ class CopyDetector:
             (len(self.test_files), len(self.ref_files)), -1
         )
         self.slice_matrix = {}
-
-        if not self.conf.silent:
-            print(f"{time.time()-start_time:6.2f}: Beginning code comparison")
 
         # this is used to track which files have been compared to avoid
         # unnecessary duplication when there is overlap between the
@@ -446,9 +439,6 @@ class CopyDetector:
                 self.similarity_matrix[i, j] = np.array([sim1, sim2])
                 self.token_overlap_matrix[i, j] = overlap
 
-        if not self.conf.silent:
-            print(f"{time.time()-start_time:6.2f}: Code comparison completed")
-
     def run(self):
         """Runs the copy detection loop for detecting overlap between
         test and reference files. If no files are in the provided
@@ -462,7 +452,20 @@ class CopyDetector:
             logging.error("Copy detector failed: No files found in "
                           "reference directories")
         else:
+            start_time = time.time()
+
+            if not self.conf.silent:
+                print("  0.00: Generating file fingerprints")
+
+            self._preprocess_code(self.test_files + self.ref_files)
+
+            if not self.conf.silent:
+                print(f"{time.time()-start_time:6.2f}: Beginning code comparison")
+
             self._comparison_loop()
+
+            if not self.conf.silent:
+                print(f"{time.time()-start_time:6.2f}: Code comparison completed")
 
     def get_copied_code_list(self):
         """Get a list of copied code to display on the output report.


### PR DESCRIPTION
Hi,

the submission base I have to work with for one of my projects is so large (>600 individual submissions) that adding all submissions I want to check at the same time makes the UI unusable (not really the issue).

The current fix is to run copydetect once for every submission with that one being the sole entry in `self.test_files`. This works well apart from the fact that for each run, all fingerprints are computed again. 

The code is already structured very well and my proposal is to separate the fingerprinting and the actual comparison loop. This breaks no public functions and interfaces but allows for a single calling of `_preprocess_code` and multiple runs of `_comparison_loop`, in between which the entries of `self.test_files` can be changed. 

The commit contained in this pull request passes all tests. 

Thanks for the great project, this is a major step up from the systems we used before!

Cheers,
Alex