### PR TITLE
a solution to exclude patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Configuration options can be provided either by using the command line arguments
 
 - `test_directories` (`-t`, `--test-dirs`): a list of directories to recursively search for files to check for plagiarism.
 - `reference_directories` (`-r`, `--ref-dirs`): a list of directories to search for files to compare the test files to. This should generally be a superset of `test_directories`. If not provided, the test directories are used as reference directories.
+- `exclude_patterns` (`-x`, `--exclude-patterns`): a list of regular expressions which to exclude files. Non-JSON escape sequences (for example, `\d` and `\.`) must be written with an escaped slash `\\`. Any containing directory- or file- name will cause files to be excluded.
 - `boilerplate_directories` (`-b`, `--boilerplate-dirs`): a list of directories containing boilerplate code. Matches between fingerprints present in the boilerplate code will not be considered plagiarism.
 - `extensions` (`-e`, `--extensions`): a list of file extensions containing code the detector should look at.
 - `noise_threshold` (`-n`, `--noise-thresh`): the smallest sequence of matching characters between two files which should be considered plagiarism. Note that tokenization and filtering replaces variable names with `V`, function names with `F`, object names with `O`, and strings with `S` so the threshold should be lower than you would expect from the original code.

--- a/copydetect/__main__.py
+++ b/copydetect/__main__.py
@@ -29,6 +29,10 @@ def main():
                         help="list of directories to recursively search for "
                         "files to compare the test files to. If left empty, "
                         "the test directories themselves are used")
+    parser.add_argument("-x", "--exclude-patterns", nargs='+',
+                        metavar="EXCLUDE-PATTERNS",
+                        help="list of regex patterns of files and directories "
+                             "to exclude files to check for plagairism")
     parser.add_argument("-b", "--boilerplate-dirs", nargs='+',
                         metavar="BOILERPLATE-DIRECTORY", default=[],
                         help="list of directories to recursively search for "
@@ -104,6 +108,7 @@ def main():
         config = {
           "test_directories" : args.test_dirs,
           "reference_directories" : args.ref_dirs,
+          "exclude_patterns" : args.exclude_patterns,
           "boilerplate_directories" : args.boilerplate_dirs,
           "extensions" : args.extensions,
           "noise_threshold" : args.noise_thresh,

--- a/copydetect/_config.py
+++ b/copydetect/_config.py
@@ -1,9 +1,9 @@
+import re
 from dataclasses import dataclass, field, asdict
-from typing import Optional, List, Dict, ClassVar
+from typing import Optional, List, Dict, ClassVar, Pattern
 from pathlib import Path
 
 from copydetect import defaults
-
 
 @dataclass
 class CopydetectConfig:
@@ -14,6 +14,9 @@ class CopydetectConfig:
 
     test_dirs: List[str] = field(default_factory=lambda: [])
     ref_dirs: Optional[List[str]] = field(default_factory=lambda: [])
+    exclude_patterns: Optional[List[str]] = None
+    # v3.8 and earlier use typing.Pattern, deprecated since 3.9 for re.Pattern
+    exclude_regexes: Optional[Pattern[str]] = ()
     boilerplate_dirs: Optional[List[str]] = field(default_factory=lambda: [])
     extensions: Optional[List[str]] = field(default_factory=lambda: ["*"])
     noise_t: int = defaults.NOISE_THRESHOLD
@@ -46,6 +49,9 @@ class CopydetectConfig:
             raise TypeError("Test directories must be a list")
         if not isinstance(self.ref_dirs, list):
             raise TypeError("Reference directories must be a list")
+        if self.exclude_patterns is not None:
+            if not isinstance(self.exclude_patterns, list):
+                raise TypeError("Exclude patterns must be a list")
         if not isinstance(self.extensions, list):
             raise TypeError("extensions must be a list")
         if not isinstance(self.boilerplate_dirs, list):
@@ -115,6 +121,8 @@ class CopydetectConfig:
         del dict_params["autoopen"]
         if self.force_language is None:
             del dict_params["force_language"]
+        if "exclude_regexes" in dict_params:
+            del dict_params["exclude_regexes"]
         return dict_params
 
     @staticmethod
@@ -140,3 +148,6 @@ class CopydetectConfig:
         self.out_file = self.normalize_outfile(self.out_file)
         self.window_size = self.guarantee_t - self.noise_t + 1
         self._check_arguments()
+        if self.exclude_patterns is not None:
+            self.exclude_regexes = [re.compile(pattern) \
+                                    for pattern in self.exclude_patterns]

--- a/copydetect/detector.py
+++ b/copydetect/detector.py
@@ -11,6 +11,7 @@ import importlib.resources
 import io
 import base64
 import json
+import os
 
 from tqdm import tqdm
 import numpy as np
@@ -195,6 +196,8 @@ class CopyDetector:
         (reference_directories) A list of directories to search for
         files to compare the test files to. This should generally be a
         superset of test_directories
+    exclude_patterns: list
+        A list of regex patterns to exclude files or directories
     boilerplate_dirs : list
         (boilerplate_directories) A list of directories containing
         boilerplate code. Matches between fingerprints present in the
@@ -248,6 +251,7 @@ class CopyDetector:
         detect file encoding
     """
     def __init__(self, test_dirs=None, ref_dirs=None,
+                 exclude_patterns=None,
                  boilerplate_dirs=None, extensions=None,
                  noise_t=defaults.NOISE_THRESHOLD,
                  guarantee_t=defaults.GUARANTEE_THRESHOLD,
@@ -265,13 +269,16 @@ class CopyDetector:
         self.conf = CopydetectConfig(**conf_args)
 
         self.test_files = self._get_file_list(
-            self.conf.test_dirs, self.conf.extensions
+            self.conf.test_dirs, self.conf.extensions,
+            self.conf.exclude_regexes
         )
         self.ref_files = self._get_file_list(
-            self.conf.ref_dirs, self.conf.extensions
+            self.conf.ref_dirs, self.conf.extensions,
+            self.conf.exclude_regexes
         )
         self.boilerplate_files = self._get_file_list(
-            self.conf.boilerplate_dirs, self.conf.extensions
+            self.conf.boilerplate_dirs, self.conf.extensions,
+            self.conf.exclude_regexes
         )
 
         # before run() is called, similarity data should be empty
@@ -298,25 +305,28 @@ class CopyDetector:
         params = CopydetectConfig.normalize_json(config)
         return cls(**params)
 
-    def _get_file_list(self, dirs, exts):
+    def _get_file_list(self, dirs, exts, exclude):
         """Recursively collects list of files from provided
         directories. Used to search test_dirs, ref_dirs, and
         boilerplate_dirs
         """
         file_list = []
         for dir in dirs:
-            print_warning = True
+            #if include and not any(i.match(dir) for i in include):
+            if any(x.match(dir) for x in exclude):
+                continue
+            files = []
             for ext in exts:
                 if ext == "*":
                     matched_contents = Path(dir).rglob("*")
                 else:
                     matched_contents = Path(dir).rglob("*."+ext.lstrip("."))
-                files = [str(f) for f in matched_contents if f.is_file()]
-
-                if len(files) > 0:
-                    print_warning = False
+                files.extend([str(f) for f in matched_contents if f.is_file()])
+            files = [f for f in files if not \
+                any(x.match(p) for x in exclude for p in f.split(os.path.sep))]
+            if len(files) > 0:
                 file_list.extend(files)
-            if print_warning:
+            else:
                 logging.warning("No files found in " + dir)
 
         # convert to a set to remove duplicates, then back to a list

--- a/docs/cmdline.rst
+++ b/docs/cmdline.rst
@@ -20,6 +20,7 @@ Configuration options can be provided either by using the command line arguments
 
 - ``test_directories`` (``-t``, ``--test-dirs``): a list of directories to recursively search for files to check for plagiarism.
 - ``reference_directories`` (``-r``, ``--ref-dirs``): a list of directories to search for files to compare the test files to. This should generally be a superset of ``test_directories``. If not provided, the test directories are used as reference directories.
+- ``exclude_patterns`` (``-x``, ``--exclude-patterns``): a list of regular expressions which to exclude files. Non-JSON escape sequences (for example, `\d` and `\.`) must be written with an escaped slash `\\`. Any containing directory- or file- name will cause files to be excluded.
 - ``boilerplate_directories`` (``-b``, ``--boilerplate-dirs``): a list of directories containing boilerplate code. Matches between fingerprints present in the boilerplate code will not be considered plagiarism.
 - ``extensions`` (``-e``, ``--extensions``): a list of file extensions containing code the detector should look at.
 - ``noise_threshold`` (``-n``, ``--noise-thresh``): the smallest sequence of matching characters between two files which should be considered plagiarism. Note that tokenization and filtering replaces variable names with ``V``, function names with ``F``, object names with ``O``, and strings with ``S`` so the threshold should be lower than you would expect from the original code.


### PR DESCRIPTION
I added this to exclude a pattern in a filename. I also tested this with directory names, it is pretty straightforward. The pytests all pass.

This addresses #50 .

I added a note in the README, we use re compile and match with the compiled objects. The exclude patterns go through JSON, so we can't take a pattern like `\.` we have to escape the slash and then put a period. Python's re will still take it.

In the _config.py, I use `typing.Pattern` for the regex objects, but from python v3.9 it will be `re.Pattern`.

in detector.py:_get_file_list
I moved the files = [] outside of the extension loop, so files can collect all files for the directory and the warning or file_list.extend(files) can happen after the regex match check.
The pattern match could be done within the loop, but the lines are getting a bit long.

I figured I'd just demonstrate the exclude rather than doubling the number of lines to look at,
extending it to have include patterns just adds lines next to the new exclude lines:
if we have include patterns and not any ( pattern in include matches ) then we skip
if we have exclude patterns and any( pattern in exclude matches ) then we skip